### PR TITLE
Improved partitioning and sharding for GEMV

### DIFF
--- a/legate/numpy/deferred.py
+++ b/legate/numpy/deferred.py
@@ -4842,22 +4842,22 @@ class DeferredArray(NumPyThunk):
             def consider_array(arr):
                 nonlocal launch_space
                 nonlocal key_array
-                s = arr.compute_parallel_launch_space()
                 if (
-                    s is not None
-                    and result.shape == arr.shape
-                    and (
-                        launch_space is None
-                        or calculate_volume(s)
-                        <= calculate_volume(launch_space)
-                    )
+                    lhs_array.shape != arr.shape
+                    or isinstance(arr.base, Future)
+                    or not arr.base.has_parallel_launch_space()
                 ):
-                    launch_space = s
-                    key_array = arr
+                    return
+                arr_space = arr.base.compute_parallel_launch_space()
+                if launch_space is None or calculate_volume(
+                    arr_space
+                ) <= calculate_volume(launch_space):
+                    launch_space = arr_space
+                    key_array = arr.base
 
-            consider_array(result)
-            consider_array(rhs1)
-            consider_array(rhs2)
+            consider_array(lhs_array)
+            consider_array(rhs1_array)
+            consider_array(rhs2_array)
             # Compute our transforms
             if rhs1_array.size > 1 and rhs1_array.shape != lhs_array.shape:
                 (

--- a/legate/numpy/deferred.py
+++ b/legate/numpy/deferred.py
@@ -4839,13 +4839,13 @@ class DeferredArray(NumPyThunk):
             launch_space = None
             key_array = None
             for arr in lhs_array, rhs1_array, rhs2_array:
-                if (
-                    lhs_array.shape != arr.shape
-                    or isinstance(arr.base, Future)
-                    or not arr.base.has_parallel_launch_space()
+                if lhs_array.shape != arr.shape or isinstance(
+                    arr.base, Future
                 ):
                     continue
                 arr_space = arr.base.compute_parallel_launch_space()
+                if arr_space is None:
+                    continue
                 if launch_space is None or calculate_volume(
                     arr_space
                 ) <= calculate_volume(launch_space):

--- a/legate/numpy/deferred.py
+++ b/legate/numpy/deferred.py
@@ -4838,26 +4838,19 @@ class DeferredArray(NumPyThunk):
             # preserve).
             launch_space = None
             key_array = None
-
-            def consider_array(arr):
-                nonlocal launch_space
-                nonlocal key_array
+            for arr in lhs_array, rhs1_array, rhs2_array:
                 if (
                     lhs_array.shape != arr.shape
                     or isinstance(arr.base, Future)
                     or not arr.base.has_parallel_launch_space()
                 ):
-                    return
+                    continue
                 arr_space = arr.base.compute_parallel_launch_space()
                 if launch_space is None or calculate_volume(
                     arr_space
                 ) <= calculate_volume(launch_space):
                     launch_space = arr_space
                     key_array = arr.base
-
-            consider_array(lhs_array)
-            consider_array(rhs1_array)
-            consider_array(rhs2_array)
             # Compute our transforms
             if rhs1_array.size > 1 and rhs1_array.shape != lhs_array.shape:
                 (

--- a/legate/numpy/runtime.py
+++ b/legate/numpy/runtime.py
@@ -1800,7 +1800,7 @@ class Runtime(object):
             self.perform_detachments()
         if self.pending_detachments:
             self.prune_detachments()
-        # Launch the operation, always user our mapper
+        # Launch the operation, always use our mapper
         if redop:
             return operation.launch(self.runtime, self.context, redop)
         else:

--- a/legate/numpy/runtime.py
+++ b/legate/numpy/runtime.py
@@ -522,9 +522,18 @@ class RegionField(object):
         assert self.launch_space is not None
         return self.shard_point, self.shard_function, self.shard_space
 
-    def set_key_partition(self, part, shardfn, shardsp):
+    def set_key_partition(self, part, shardfn=None, shardsp=None):
+        assert part.parent == self.region
         self.launch_space = part.color_shape
         self.key_partition = part
+        if shardfn is None:
+            assert shardsp is None
+            shardfn = (
+                self.runtime.first_shard_id
+                + legate_numpy.NUMPY_SHARD_TILE_1D
+                + len(self.shape)
+                - 1
+            )
         self.shard_function = shardfn
         self.shard_space = shardsp
 

--- a/src/legate_numpy_c.h
+++ b/src/legate_numpy_c.h
@@ -109,14 +109,14 @@ enum NumPyOpCode {
   NUMPY_ARANGE              = 74,
 };
 
-// Match these to NumPyRedopCode in legate/core/config.py
+// Match these to NumPyRedopCode in legate/numpy/config.py
 enum NumPyRedopID {
   NUMPY_ARGMIN_REDOP,
   NUMPY_ARGMAX_REDOP,
 };
 
 // We provide a global class of projection functions
-// Match these to NumPyProjCode in legate/core/config.py
+// Match these to NumPyProjCode in legate/numpy/config.py
 enum NumPyProjectionCode {
   // 2D reduction
   NUMPY_PROJ_2D_1D_X = 1,  // keep x


### PR DESCRIPTION
Partition the output vector of a GEMV following the non-reduced dimension of the matrix (e.g. if `M` is partitioned into 5x3 tiles, partition `x = Mv` into 5 tiles).

Shard the SumRadix tasks that build the output vector of a GEMV like a 1d launch, considering only the non-reduced dimension of the matrix (e.g. shard the SumRadix 5x3 launch space above like a 1d 5-wide launch space).

If multiple arrays on a binary operation have a launch space, pick the smallest one. This is meant to capture the case where the output `x` of a GEMV goes through some vector-vector operations before being used as the input to another GEMV. In this case `x` is partitioned over a smaller color space, and switching to the full color space would mean repartitioning, that we would prefer to avoid until we get to the next GEMV.