### PR TITLE
Be strict when importing legate.numpy in examples

### DIFF
--- a/examples/gemm.py
+++ b/examples/gemm.py
@@ -23,10 +23,7 @@ import math
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def initialize(M, N, K, ft):

--- a/examples/kmeans_slow.py
+++ b/examples/kmeans_slow.py
@@ -24,10 +24,7 @@ import datetime
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def initialize(N, D, C, T):

--- a/examples/kmeans_sort.py
+++ b/examples/kmeans_sort.py
@@ -24,10 +24,7 @@ import datetime
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 try:
     xrange

--- a/examples/linreg.py
+++ b/examples/linreg.py
@@ -23,10 +23,7 @@ import math
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def initialize(N, F, T):

--- a/examples/logreg.py
+++ b/examples/logreg.py
@@ -23,10 +23,7 @@ import math
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def initialize(N, F, T):

--- a/examples/lstm_backward.py
+++ b/examples/lstm_backward.py
@@ -23,10 +23,7 @@ import math
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def run_lstm(batch_size, hidden_size, sentence_length, word_size, timing):

--- a/examples/lstm_forward.py
+++ b/examples/lstm_forward.py
@@ -23,10 +23,7 @@ import math
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def run_lstm(batch_size, hidden_size, sentence_length, word_size, timing):

--- a/examples/lstm_full.py
+++ b/examples/lstm_full.py
@@ -22,10 +22,7 @@ import datetime
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 class Param:

--- a/examples/stencil.py
+++ b/examples/stencil.py
@@ -23,10 +23,7 @@ import math
 
 from benchmark import run_benchmark
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def initialize(N):

--- a/examples/wgrad.py
+++ b/examples/wgrad.py
@@ -21,10 +21,7 @@ import argparse
 import datetime
 import math
 
-try:
-    import legate.numpy as np
-except ImportError:
-    import numpy as np
+import legate.numpy as np
 
 
 def initialize(C, K, B, H, W):


### PR DESCRIPTION
In multiple occasions the previous behavior of falling back to
vanilla NumPy on ImportError has masked errors in the configuration,
where legate.numpy was really not working, but there was no
indication of this when running the examples.