### PR TITLE
Fix for reinterpret casts that are actually unsafe in the modern c++

### DIFF
--- a/src/scalar.cc
+++ b/src/scalar.cc
@@ -82,10 +82,15 @@ struct copy_fn {
   void* operator()(bool is_argval, const void* ptr)
   {
     using VAL = legate_type_of<CODE>;
-    if (is_argval)
-      return new Argval<VAL>(*static_cast<const Argval<VAL>*>(ptr));
-    else
-      return new VAL(*static_cast<const VAL*>(ptr));
+    if (is_argval) {
+      auto result = new Argval<VAL>();
+      memcpy(result, ptr, sizeof(Argval<VAL>));
+      return result;
+    } else {
+      auto result = new VAL();
+      memcpy(result, ptr, sizeof(VAL));
+      return result;
+    }
   }
 };
 

--- a/src/scalar.h
+++ b/src/scalar.h
@@ -61,21 +61,14 @@ class UntypedScalar {
 
  public:
   template <typename T>
-  const T& value() const
+  T value() const
   {
-    return *static_cast<const T*>(data_);
+    T result{};
+    memcpy(&result, data_, sizeof(T));
+    return result;
   }
-  template <typename T = void>
-  const T* ptr() const
-  {
-    return static_cast<const T*>(data_);
-  }
-
-  template <typename T = void>
-  T* ptr()
-  {
-    return static_cast<T*>(data_);
-  }
+  const void* ptr() const { return data_; }
+  void* ptr() { return data_; }
 
   std::string to_string() const;
 


### PR DESCRIPTION
It turns out that I was still living in the stone age and writing code illegal in the modern C++. This PR is to fix those errors I found in the untyped scalar implementation.