### PR TITLE
Remove the return type of the void-returning function in the mapper

### DIFF
--- a/src/mapper.h
+++ b/src/mapper.h
@@ -111,7 +111,7 @@ class NumPyMapper : public Legion::Mapping::Mapper {
         }
       return instances.empty();
     }
-    inline bool erase(unsigned idx)
+    inline void erase(unsigned idx)
     {
       // We also need to update any of the other region mappings
       for (std::map<Legion::LogicalRegion, unsigned>::iterator it = region_mapping.begin();


### PR DESCRIPTION
This fixes the bug that assigned a return type to the function that returned nothing. This simple mistake actually led to a rather spectacular crash (the crash blew up the whole stack and there's no clue whatsoever on what caused it). I suspect the compiler was doing some wild optimizations for inline functions under the assumption that they are faithful to their signatures. I'm leaving this note so that others won't repeat the same mistake as I did.