### PR TITLE
Disable absolute and allcose for complex types only with Clang

### DIFF
--- a/src/binary/binary_op_util.h
+++ b/src/binary/binary_op_util.h
@@ -332,6 +332,10 @@ struct BinaryOp<BinaryOpCode::ALLCLOSE, CODE> {
   double atol_{0};
 };
 
+#if defined(__clang__) && !defined(__NVCC__)
+
+// Clang doesn't seem to support fabs for complex types, so we turn them off
+
 template <>
 struct BinaryOp<BinaryOpCode::ALLCLOSE, LegateTypeCode::COMPLEX64_LT> {
   static constexpr bool valid = false;
@@ -345,6 +349,8 @@ struct BinaryOp<BinaryOpCode::ALLCLOSE, LegateTypeCode::COMPLEX128_LT> {
   BinaryOp() {}
   BinaryOp(const std::vector<UntypedScalar>& args) {}
 };
+
+#endif
 
 }  // namespace numpy
 }  // namespace legate

--- a/src/unary/unary_op_util.h
+++ b/src/unary/unary_op_util.h
@@ -144,6 +144,10 @@ struct UnaryOp<UnaryOpCode::ABSOLUTE, CODE> {
   }
 };
 
+#if defined(__clang__) && !defined(__NVCC__)
+
+// Clang doesn't seem to support fabs for complex types, so we turn them off
+
 template <>
 struct UnaryOp<UnaryOpCode::ABSOLUTE, LegateTypeCode::COMPLEX64_LT> {
   static constexpr bool valid = false;
@@ -157,6 +161,8 @@ struct UnaryOp<UnaryOpCode::ABSOLUTE, LegateTypeCode::COMPLEX128_LT> {
   UnaryOp() {}
   UnaryOp(const std::vector<UntypedScalar>& args) {}
 };
+
+#endif
 
 template <LegateTypeCode CODE>
 struct UnaryOp<UnaryOpCode::ARCCOS, CODE> {


### PR DESCRIPTION
#99a18d8 was breaking a bunch of CI tests, and this is an attempt to fix it. Until we find a way to use `fabs` with complex numbers on Mac, we disable the complex operators that rely on it if Clang is being used.