### PR TITLE
Improve dot product for half precision floats

### DIFF
--- a/src/matrix/dot.cc
+++ b/src/matrix/dot.cc
@@ -25,8 +25,9 @@ using namespace Legion;
 template <LegateTypeCode CODE>
 struct DotImplBody<VariantKind::CPU, CODE> {
   using VAL = legate_type_of<CODE>;
+  using ACC = acc_type_of<VAL>;
 
-  void operator()(VAL& result,
+  void operator()(ACC& result,
                   const AccessorRO<VAL, 1>& rhs1,
                   const AccessorRO<VAL, 1>& rhs2,
                   const Rect<1>& rect,
@@ -37,13 +38,13 @@ struct DotImplBody<VariantKind::CPU, CODE> {
       auto rhs1ptr = rhs1.ptr(rect);
       auto rhs2ptr = rhs2.ptr(rect);
       for (coord_t idx = 0; idx < volume; ++idx) {
-        const VAL prod = rhs1ptr[idx] * rhs2ptr[idx];
-        SumReduction<VAL>::template fold<true>(result, prod);
+        const auto prod = static_cast<ACC>(rhs1ptr[idx]) * static_cast<ACC>(rhs2ptr[idx]);
+        SumReduction<ACC>::template fold<true>(result, prod);
       }
     } else {
       for (coord_t idx = rect.lo[0]; idx <= rect.hi[0]; ++idx) {
-        const VAL prod = rhs1[idx] * rhs2[idx];
-        SumReduction<VAL>::template fold<true>(result, prod);
+        const auto prod = static_cast<ACC>(rhs1[idx]) * static_cast<ACC>(rhs2[idx]);
+        SumReduction<ACC>::template fold<true>(result, prod);
       }
     }
   }

--- a/src/matrix/dot_template.inl
+++ b/src/matrix/dot_template.inl
@@ -22,18 +22,32 @@ using namespace Legion;
 template <VariantKind KIND, LegateTypeCode CODE>
 struct DotImplBody;
 
+template <typename VAL>
+struct AccTypeOf {
+  using type = VAL;
+};
+
+template <>
+struct AccTypeOf<__half> {
+  using type = float;
+};
+
+template <typename VAL>
+using acc_type_of = typename AccTypeOf<VAL>::type;
+
 template <VariantKind KIND>
 struct DotImpl {
   template <LegateTypeCode CODE>
   UntypedScalar operator()(DotArgs& args) const
   {
     using VAL = legate_type_of<CODE>;
+    using ACC = acc_type_of<VAL>;
 
     assert(args.rhs1.dim() == 1);
     assert(args.rhs2.dim() == 1);
 
     auto rect  = args.rhs1.shape<1>();
-    VAL result = SumReduction<VAL>::identity;
+    ACC result = SumReduction<ACC>::identity;
 
     if (rect.empty()) return UntypedScalar(result);
 

--- a/tests/matrix_mul.py
+++ b/tests/matrix_mul.py
@@ -19,8 +19,8 @@ import legate.numpy as lg
 
 
 def test(ty):
-
     np.random.seed(42)
+
     A = lg.random.randn(6, 3, 7).astype(ty)
     B = lg.random.randn(4, 7, 11).astype(ty)
     C = A[1].dot(B[2])
@@ -72,6 +72,16 @@ def test(ty):
     A3[0] = A3np[0]
     B3[0] = B3np[0]
     C = A3[0].T.dot(B3[0].T)
+
+    assert np.allclose(C, Cn)
+
+    A = lg.random.randn(1, 10).astype(ty)
+    B = lg.random.randn(10, 1).astype(ty)
+    C = A.dot(B)
+
+    An = A.__array__()
+    Bn = B.__array__()
+    Cn = An.dot(Bn)
 
     assert np.allclose(C, Cn)
 

--- a/tests/matrix_vec.py
+++ b/tests/matrix_vec.py
@@ -60,6 +60,26 @@ def test(ty):
 
     assert np.allclose(C, Cn)
 
+    A = lg.random.randn(1, 10).astype(ty)
+    B = lg.random.randn(10).astype(ty)
+    C = A.dot(B)
+
+    An = A.__array__()
+    Bn = B.__array__()
+    Cn = An.dot(Bn)
+
+    assert np.allclose(C, Cn)
+
+    A = lg.random.randn(10).astype(ty)
+    B = lg.random.randn(10, 1).astype(ty)
+    C = A.dot(B)
+
+    An = A.__array__()
+    Bn = B.__array__()
+    Cn = An.dot(Bn)
+
+    assert np.allclose(C, Cn)
+
 
 if __name__ == "__main__":
     test(np.float16)


### PR DESCRIPTION
This PR is to use 32-bit accumulator in dot products for half precision floating numbers. This also includes changes to use dot product for degenerate cases of matrix-matrix and matrix-vector products.