### PR TITLE
Support for tensordot

### DIFF
--- a/legate/numpy/array.py
+++ b/legate/numpy/array.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 #
 
-from __future__ import absolute_import, division, print_function
-
 import warnings
+from collections.abc import Iterable
 from functools import reduce
 
 import numpy as np
@@ -32,6 +31,7 @@ from .utils import unimplemented
 def broadcast_shapes(*args):
     arrays = [np.empty(x, dtype=[]) for x in args]
     return np.broadcast(*arrays).shape
+
 
 @copy_docstring(np.ndarray)
 class ndarray(object):
@@ -1292,7 +1292,7 @@ class ndarray(object):
     def reshape(self, shape, order="C", stacklevel=1):
         if shape != -1:
             # Check that these sizes are compatible
-            if isinstance(shape, tuple):
+            if isinstance(shape, Iterable):
                 newsize = 1
                 newshape = list()
                 unknown_axis = -1
@@ -1516,7 +1516,7 @@ class ndarray(object):
             axes = tuple(range(self.ndim - 1, -1, -1))
         elif len(axes) == self.ndim:
             result = ndarray(
-                shape=tuple(map(lambda x, y: x[y], self.shape, axes)),
+                shape=tuple(self.shape[idx] for idx in axes),
                 dtype=self.dtype,
                 stacklevel=(stacklevel + 1),
             )

--- a/legate/numpy/deferred.py
+++ b/legate/numpy/deferred.py
@@ -15,6 +15,7 @@
 
 import warnings
 import weakref
+from collections.abc import Iterable
 from functools import reduce
 
 import numpy as np
@@ -511,7 +512,7 @@ class DeferredArray(NumPyThunk):
             self.runtime.check_shadow(self, "set_item")
 
     def reshape(self, newshape, order, stacklevel):
-        assert isinstance(newshape, tuple)
+        assert isinstance(newshape, Iterable)
         if order == "A":
             order = "C"
 

--- a/legate/numpy/module.py
+++ b/legate/numpy/module.py
@@ -417,6 +417,73 @@ def dot(a, b, out=None):
     return a_array.dot(b, out=out, stacklevel=2)
 
 
+@copy_docstring(np.tensordot)
+def tensordot(a, b, axes=2):
+    # This is the exact same code as the canonical numpy.
+    # See https://github.com/numpy/numpy/blob/v1.21.0/numpy/core/numeric.py#L943-L1133. # noqa:  E501
+    try:
+        iter(axes)
+    except Exception:
+        axes_a = list(range(-axes, 0))
+        axes_b = list(range(0, axes))
+    else:
+        axes_a, axes_b = axes
+    try:
+        na = len(axes_a)
+        axes_a = list(axes_a)
+    except TypeError:
+        axes_a = [axes_a]
+        na = 1
+    try:
+        nb = len(axes_b)
+        axes_b = list(axes_b)
+    except TypeError:
+        axes_b = [axes_b]
+        nb = 1
+
+    as_ = a.shape
+    nda = a.ndim
+    bs = b.shape
+    ndb = b.ndim
+    equal = True
+    if na != nb:
+        equal = False
+    else:
+        for k in range(na):
+            if as_[axes_a[k]] != bs[axes_b[k]]:
+                equal = False
+                break
+            if axes_a[k] < 0:
+                axes_a[k] += nda
+            if axes_b[k] < 0:
+                axes_b[k] += ndb
+    if not equal:
+        raise ValueError("shape-mismatch for sum")
+
+    # Move the axes to sum over to the end of "a"
+    # and to the front of "b"
+    notin = [k for k in range(nda) if k not in axes_a]
+    newaxes_a = notin + axes_a
+    N2 = 1
+    for axis in axes_a:
+        N2 *= as_[axis]
+    newshape_a = (int(np.multiply.reduce([as_[ax] for ax in notin])), N2)
+    olda = [as_[axis] for axis in notin]
+
+    notin = [k for k in range(ndb) if k not in axes_b]
+    newaxes_b = axes_b + notin
+    N2 = 1
+    for axis in axes_b:
+        N2 *= bs[axis]
+    newshape_b = (N2, int(np.multiply.reduce([bs[ax] for ax in notin])))
+    oldb = [bs[axis] for axis in notin]
+
+    at = a.transpose(newaxes_a).reshape(newshape_a)
+    bt = b.transpose(newaxes_b).reshape(newshape_b)
+    res = dot(at, bt)
+    return res.reshape(olda + oldb)
+
+
 # ### LOGIC FUNCTIONS
 
 

--- a/tests/tensordot.py
+++ b/tests/tensordot.py
@@ -1,0 +1,66 @@
+# Copyright 2021 NVIDIA Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+
+import legate.numpy as lg
+
+
+def test(ty):
+    a = lg.random.rand(3, 5, 4).astype(ty)
+    b = lg.random.rand(4, 5, 3).astype(ty)
+
+    cn = np.tensordot(a, b, axes=1)
+    c = lg.tensordot(a, b, axes=1)
+
+    assert np.allclose(cn, c)
+
+    a = lg.random.rand(3, 5, 4).astype(ty)
+    b = lg.random.rand(5, 4, 3).astype(ty)
+
+    cn = np.tensordot(a, b)
+    c = lg.tensordot(a, b)
+
+    assert np.allclose(cn, c)
+
+    a = lg.arange(60.0).reshape((3, 4, 5)).astype(ty)
+    b = lg.arange(24.0).reshape((4, 3, 2)).astype(ty)
+
+    cn = np.tensordot(a, b, axes=([1, 0], [0, 1]))
+    c = lg.tensordot(a, b, axes=([1, 0], [0, 1]))
+
+    assert np.allclose(cn, c)
+
+    a = lg.random.rand(5, 4).astype(ty)
+    b = lg.random.rand(4, 5).astype(ty)
+
+    cn = np.tensordot(a, b, axes=1)
+    c = lg.tensordot(a, b, axes=1)
+
+    assert np.allclose(cn, c)
+
+    a = lg.random.rand(5, 4).astype(ty)
+    b = lg.random.rand(5, 4).astype(ty)
+
+    cn = np.tensordot(a, b)
+    c = lg.tensordot(a, b)
+
+    assert np.allclose(cn, c)
+
+
+if __name__ == "__main__":
+    test(np.float16)
+    test(np.float32)
+    test(np.float64)


### PR DESCRIPTION
This PR includes changes to support `tensordot`. As stated in the comment,  the added `tensordot` code is exactly the same as that in the canonical numpy, thanks to the generalized `reshape` implementation.