### PR TITLE
Pull the correct Core image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
   PROJECT: github-numpy-ci
+  REF: ${{ github.event.pull_request.head.ref || github.ref }}
+  BASE_REF: ${{ github.event.pull_request.base.ref || github.ref }}
+  EVENT_NAME: ${{ github.event_name }}
+  LABEL: ${{ github.event.pull_request.head.label }}
   # Prevent output buffering
   PYTHONUNBUFFERED: 1
 jobs:


### PR DESCRIPTION
If the branch name matches the target repo in a pull request, pull the image for the same branch from the Core repository. If the branch name does not match the target branch, generate a label consisting of the fork repo owner and the branch name, and use it to look up the corresponding label for core.