### PR TITLE
Emptiness checks for matrix ops

### DIFF
--- a/src/matrix/matmul_template.inl
+++ b/src/matrix/matmul_template.inl
@@ -54,6 +54,8 @@ struct MatMulImpl {
     // in their bloated domains.
     auto shape = args.rhs1.shape<3>().intersection(args.rhs2.shape<3>());
 
+    if (shape.empty()) return;
+
     const auto m = shape.hi[0] - shape.lo[0] + 1;
     const auto k = shape.hi[1] - shape.lo[1] + 1;
     const auto n = shape.hi[2] - shape.lo[2] + 1;

--- a/src/matrix/matvecmul_template.inl
+++ b/src/matrix/matvecmul_template.inl
@@ -47,8 +47,11 @@ struct MatVecMulImpl {
     using ACC = typename support_matvecmul<CODE>::ACC_TYPE;
 
     auto shape = args.rhs1.shape<2>().intersection(args.rhs2.shape<2>());
-    auto m     = static_cast<size_t>(shape.hi[0] - shape.lo[0] + 1);
-    auto n     = static_cast<size_t>(shape.hi[1] - shape.lo[1] + 1);
+
+    if (shape.empty()) return;
+
+    auto m = static_cast<size_t>(shape.hi[0] - shape.lo[0] + 1);
+    auto n = static_cast<size_t>(shape.hi[1] - shape.lo[1] + 1);
 
     size_t mat_stride  = 0;
     bool transpose_mat = false;


### PR DESCRIPTION
There was a bug in matrix ops that tries to allocate a really big buffer when the input shape was empty. This PR is to fix that bug.